### PR TITLE
Reserved slot in spring2024.md

### DIFF
--- a/meetings/spring2024.md
+++ b/meetings/spring2024.md
@@ -6,7 +6,7 @@
 - February 8: CANCELLED - Prof. Novak at NCSU
 - February 15:
 - February 22:
-- February 29:
+- February 29: MontePy (Micah Gale [INL] w/ Travis)
 - March 7:Michael - A slug flow model with concave interface for gas-liquid flow in horizontal pipes.
 - March 14: CANCELLED - spring break
 - March 21: Ansh (TBD)


### PR DESCRIPTION
@mgale and @tjlaboss might present something on [MontePy](https://github.com/idaholab/MontePy/), a Python API for MCNP input decks, on February 29. 

Pending laboratory external release approval.